### PR TITLE
Update hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -1,4 +1,4 @@
-# 2020.0103.1
+# 2020.0204.1
 # --------------------------------------------------
 # AdGuard
 @@||adguard.com^
@@ -39,6 +39,10 @@
 @@||cloud.unity3d.com^
 @@||s.youtube.com^
 @@||static.zdassets.com^
+@@||nba.com^
+@@||crowdin.com^
+@@||ipapi.co^
+@@||t.ly^
 # Blocklist
 ||ettoday.com^
 ||pixnet.com^


### PR DESCRIPTION
新增起個常用的被誤封的服務

## nba.com
會無法正常開啟

## ipapi.io
被 `AdGuard Simplified Domain Names Filter` 給阻擋

## crowdin.com
常見翻譯平台的 `api` subdomain 會被 EnergizedProtection  block

## t.ly
縮網址服務